### PR TITLE
[B] Anpassung für Tibco bzw. Abfangen der Ping-Querys

### DIFF
--- a/driver/src/main/java/com/consol/citrus/db/driver/JdbcStatement.java
+++ b/driver/src/main/java/com/consol/citrus/db/driver/JdbcStatement.java
@@ -60,6 +60,10 @@ public class JdbcStatement implements Statement {
     public java.sql.ResultSet executeQuery(final String sqlQuery) throws SQLException {
         HttpResponse response = null;
         try {
+        	//Tibco Ping-Queries abfangen
+	        if (sqlQuery.equals("SELECT USER from DUAL")){
+	        	return new JdbcResultSet(null, this);
+	        }
             response = httpClient.execute(RequestBuilder.post(serverUrl + "/query")
                     .setEntity(new StringEntity(sqlQuery, ContentType.create("text/plain", "UTF-8")))
                     .build());


### PR DESCRIPTION
Hallo Christoph, da es ja bei uns Probleme mit Tibco gibt bzw. die BWEngine an die Citrus-DB Pings sendet habe ich eine einfache Abfrage eingebaut um diese Anfragen garnicht erst an den Test gehen zu lassen.